### PR TITLE
Update Sitecost.tex : fixed wrong number

### DIFF
--- a/Sitecost.tex
+++ b/Sitecost.tex
@@ -59,7 +59,7 @@ $-20 \%$ per year for some time.
     \begin{tabular}{lcccc}
         \hline
         resource & CPU & disk & cartridge & energy \\\hline
-        average purchase cost & 10.3 \euro/HS06 & 126.5 \euro/TB & 12.8 \euro/TB & 0.1 \euro/kWh\\
+        average purchase cost & 10.3 \euro/HS06 & 126.5 \euro/TB & 22.5 \euro/TB & 0.1 \euro/kWh\\
         standard deviation & 26 \% & 51 \% & 57 \% & 54 \% \\
         average trend & -12 \%/y & -15 \%/y & -14 \%/y & n/a \\
         standard deviation & 37 \% & 20 \% & 43 \% & n/a \\\hline


### PR DESCRIPTION
There is a typo in the site cost part about the tape cost.
The 12.8 EUR/TB originally in the document is wrong, this number actually corresponds to the standard deviation around the average value that is 22.5 EUR/TB
